### PR TITLE
Allow future versions of GTK

### DIFF
--- a/inc/My/Build/Any_wx_config.pm
+++ b/inc/My/Build/Any_wx_config.pm
@@ -92,7 +92,7 @@ sub awx_configure {
     $config{config}{build} = $self->awx_is_monolithic ? 'mono' : 'multi';
 
     if( $config{config}{toolkit} eq 'gtk' ) {
-        $self->wx_config( 'basename' ) =~ m/(gtk2?)/i or
+        $self->wx_config( 'basename' ) =~ m/(gtk\d?)/i or
           die 'PANIC: ', $self->wx_config( 'basename' );
         $config{config}{toolkit} = lc $1;
     }

--- a/inc/My/Build/Any_wx_config_Bakefile.pm
+++ b/inc/My/Build/Any_wx_config_Bakefile.pm
@@ -41,9 +41,9 @@ sub awx_wx_config_data {
         $key = 'base' if $key =~ m/^carbon|^cocoa/ && $name !~ /osx_/; # here for Mac
         $key = 'core' if $key =~ m/^carbon|^cocoa/ && $name =~ /osx_/; # here for Mac
         $key = 'core' if $key =~ m/^mac[ud]{0,2}/;
-        $key = 'core' if $key =~ m/^gtk2?[ud]{0,2}/
+        $key = 'core' if $key =~ m/^gtk\d?[ud]{0,2}/
                               && $self->awx_is_monolithic
-                              && $lib =~ m/(?:gtk2?|mac)[ud]{0,2}-/;
+                              && $lib =~ m/(?:gtk\d?|mac)[ud]{0,2}-/;
         my $dll = "lib${name}." . $self->awx_dlext . $libsuffix;
 
         $data{dlls}{$key} = { dll  => $dll,


### PR DESCRIPTION
Hello,

While building WxPerl with a WxWidgets which was linked to gtk3 I noticed that Alien::WxWidgets fails to find the "core" linking libraries, and (after debugging) it lists the gtk3 libraries as separate items in the hash.

Upon further inspection in the code I was able to find that the references to gtk2 are specifically hardcoded in Alien::WxWidgets. I removed the hardcoded value and re-built it, this time it linked successfully and allowed me to build WxPerl.

On many of the newer operating systems (i.e. RHEL 10) the support for gtk2 is removed, and thus it requires the use of gtk3  or newer. From what I've tested so far gtk3 doesn't cause any other specific issues during the build or subsequent program execution.